### PR TITLE
reordering for style, fixed short bio

### DIFF
--- a/buddy_mentorship/models.py
+++ b/buddy_mentorship/models.py
@@ -35,11 +35,11 @@ class Profile(models.Model):
 
     def get_short_bio(self):
         trunc_bio = self.bio[:240]
-        if self.bio == trunc_bio:
-            return trunc_bio
         first_nl = trunc_bio.find("\n")
         if first_nl > -1:
             return trunc_bio[:first_nl]
+        if self.bio == trunc_bio:
+            return trunc_bio
         last_dot = trunc_bio.rfind(".")
         last_bang = trunc_bio.rfind("!")
         last_huh = trunc_bio.rfind("?")

--- a/buddy_mentorship/views.py
+++ b/buddy_mentorship/views.py
@@ -61,6 +61,8 @@ def can_request(requestor, requestee):
 class Search(LoginRequiredMixin, ListView):
     login_url = "login"
 
+    template_name = "buddy_mentorship/search.html"
+
     paginate_by = 5
 
     queryset = Profile.objects.all().order_by('-id')
@@ -83,8 +85,6 @@ class Search(LoginRequiredMixin, ListView):
                     rank=SearchRank(search_vector, search_query)
                 ).order_by("-rank")
         return search_results
-
-    template_name = "buddy_mentorship/search.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Short bio returned two paragraphs even if both were short; wanted it to return one paragraph. (Do not think about this one too much, it is overthought already.)

Pre-merge, @rifferreinert pointed out two model attributes should be reordered; I've also done that.