### PR TITLE
Feature/status ui

### DIFF
--- a/apps/users/admin.py
+++ b/apps/users/admin.py
@@ -11,11 +11,29 @@ class UserAdmin(UserAdmin):
     model = User
     list_display = ("email", "is_staff", "is_active", "uuid")
     list_filter = ("email", "is_staff", "is_active")
-    fieldsets = ((None, {"fields": ("email", "password", "first_name", "last_name")}), ("Permissions", {"fields": ("is_staff", "is_active")}))
+    fieldsets = (
+        (None, {"fields": ("email", "password", "first_name", "last_name")}),
+        ("Permissions", {"fields": ("is_staff", "is_active")}),
+    )
     add_fieldsets = (
-        (None, {"classes": ("wide",), "fields": ("email", "password1", "password2", "first_name", "last_name", "is_staff", "is_active")}),
+        (
+            None,
+            {
+                "classes": ("wide",),
+                "fields": (
+                    "email",
+                    "password1",
+                    "password2",
+                    "first_name",
+                    "last_name",
+                    "is_staff",
+                    "is_active",
+                ),
+            },
+        ),
     )
     search_fields = ("email",)
     ordering = ("email",)
+
 
 admin.site.register(User, UserAdmin)

--- a/apps/users/templates/users/request.html
+++ b/apps/users/templates/users/request.html
@@ -65,6 +65,27 @@
           </div>
         </div>
       </div>
+      {% if buddy_request.status == 1 %}
+        <div class="row mb-2 col card">
+          <div class="card-body">
+            <div class="card-title h5">
+              <span class="badge badge-success">Request Accepted!</span>
+            </div>
+            <div class="card-text">
+            {% if user == buddy_request.requestee %}
+              Contact {{buddy_request.requestor.first_name}} at 
+              <a href="mailto:{{ buddy_request.requestor.email }}">
+              {{ buddy_request.requestor.email }}</a>.</p>
+            {% endif %}
+            {% if user == buddy_request.requestor %}
+              Contact {{buddy_request.requestee.first_name}} at 
+              <a href="mailto:{{ buddy_request.requestee.email }}">
+              {{ buddy_request.requestee.email }}</a>.</p>
+            {% endif %}
+            </div>
+          </div>
+        </div>
+      {% endif %}
     </div>
   </div>
 

--- a/apps/users/templates/users/request.html
+++ b/apps/users/templates/users/request.html
@@ -1,15 +1,71 @@
 {% extends 'buddy_mentorship/base.html' %}
 {% block title %} Request Detail {% endblock %}
 {% block content %}
-<h2>
-    Request
-</h2>
+  <div class="container">
+    <div class="starter-template">
+      <h1>
+        Request
+      </h1>
+      <div class="row mb-2">
+        <div class="col">
+          <div class="request card">
+            <div class="card-body">
+              <div class="card-title h5">
+                From <a href="{% url 'profile' requestor_profile %}">{{ buddy_request.requestor.first_name }} {{ buddy_request.requestor.last_name }}</a> to <a href="{% url 'profile' requestee_profile %}">{{ buddy_request.requestee.first_name }} {{ buddy_request.requestee.last_name }}</a>.
+              </div>
+              <div class="card-text">
+                {{ buddy_request.message | linebreaks}}
+              </div>
+              {% if user == buddy_request.requestee and buddy_request.status == 0 %}
+                <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#acceptModal">Accept</button>
+                <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#ignoreModal">Ignore</button>
+                <form action="{% url 'update_request' buddy_request.id %}" method="post" id="update_request">
+                  {% csrf_token %}
+                  <div class="modal fade" id="acceptModal" tabindex="-1" role="dialog" aria-labelledby="acceptModalLabel" aria-hidden="true">
+                    <div class="modal-dialog" role="document">
+                      <div class="modal-content">
+                        <div class="modal-header">
+                          <h5 class="modal-title" id="acceptModalLabel">Accept Buddy Request</h5>
+                          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                          </button>
+                        </div>
+                        <div class="modal-body">
+                          Please confirm you want to accept {{buddy_request.requestor.first_name}} {{buddy_request.requestor.last_name}}'s request.
+                        </div>
+                        <div class="modal-footer">
+                          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                          <button type="submit" class="btn btn-primary" name="status" value="accept">Accept</button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="modal fade" id="ignoreModal" tabindex="-1" role="dialog" aria-labelledby="ignoreModalLabel" aria-hidden="true">
+                    <div class="modal-dialog" role="document">
+                      <div class="modal-content">
+                        <div class="modal-header">
+                          <h5 class="modal-title" id="ignoreModalLabel">Ignore Buddy Request</h5>
+                          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                          </button>
+                        </div>
+                        <div class="modal-body">
+                          Please confirm you want to ignore {{buddy_request.requestor.first_name}} {{buddy_request.requestor.last_name}}'s request.
+                        </div>
+                        <div class="modal-footer">
+                          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                          <button type="submit" class="btn btn-danger" name="status" value="ignore">Ignore</button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </form>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 
-<p>
-This is a request from {{ buddy_request.requestor.first_name }} {{ buddy_request.requestor.last_name }} to {{ buddy_request.requestee.first_name }} {{ buddy_request.requestee.last_name }}.
-</p>
-
-<p>
-{{ buddy_request.message | linebreaks}}
-</p>
 {% endblock %}

--- a/apps/users/templates/users/requests.html
+++ b/apps/users/templates/users/requests.html
@@ -2,45 +2,55 @@
 {% block title %} Requests {% endblock %}
 {% block content %}
 <h2>
-    Your Requests
+  Your Requests
 </h2>
 
 <p>
-    Requests you have received:
+  Requests you have received:
 </p>
 
 <ul>
-    {% if not requests_received %}
-        <li> You have not received any requests </li>
+  {% if not requests_received %}
+    <li> You have not received any requests </li>
+  {% endif %}
+  {% for request in requests_received %}
+    {% if request.status != 2 %}
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <a href="/requests/{{ request.id }}">
+          From: {{ request.requestor.first_name }} {{ request.requestor.last_name }}
+        </a>
+        {% if request.status == 0 %}
+          <span class="badge badge-secondary badge-pill">Pending</span>
+        {% endif %}
+        {% if request.status == 1 %}
+          <span class="badge badge-success badge-pill">Accepted</span>
+        {% endif %}
+      </li>
     {% endif %}
-    {% for request in requests_received %}
-
-        <li>
-            <a href="/requests/{{ request.id }}">
-                {{ request.requestor.first_name }} sent you a request with the message "{{ request.message }}"
-            </a>
-        </li>
-
-    {% endfor %}
-    
+  {% endfor %}
 </ul>
 
 <p>
-    Requests you have sent:
+  Requests you have sent:
 </p>
 
 <ul>
-    {% if not requests_sent %}
-        <li> You have not sent any requests </li>
-    {% endif %}
-    {% for request in requests_sent %}
-
-        <li>
-            <a href="/requests/{{ request.id }}">
-                You sent a request to {{ request.requestee.first_name }} with the message "{{ request.message }}"
-            </a>
-        </li>
-
-    {% endfor %}
+  {% if not requests_sent %}
+    <li> You have not sent any requests </li>
+  {% endif %}
+  {% for request in requests_sent %}
+    <li class="list-group-item d-flex justify-content-between align-items-center">
+      <a href="/requests/{{ request.id }}">
+        To: {{ request.requestee.first_name }} {{ request.requestee.last_name }}
+      </a>
+      {% if request.status == 0 %}
+        <span class="badge badge-secondary badge-pill">Pending</span>
+      {% endif %}
+      {% if request.status == 1 %}
+        <span class="badge badge-success badge-pill">Accepted</span>
+      {% endif %}
+    </li>
+  {% endfor %}
 </ul>
+
 {% endblock %}

--- a/apps/users/tests.py
+++ b/apps/users/tests.py
@@ -10,6 +10,7 @@ from buddy_mentorship.models import BuddyRequest, Profile
 
 import platform
 
+
 class CustomUserManagerTest(TransactionTestCase):
     def test_create_user(self):
         new_user = User.objects.create_user(email="test@user.com")
@@ -30,6 +31,7 @@ class CustomUserManagerTest(TransactionTestCase):
         assert user.first_name == "John"
         assert user.last_name == "Snow"
 
+
 class UserLoginTest(StaticLiveServerTestCase):
     @classmethod
     def setUpClass(cls):
@@ -37,10 +39,10 @@ class UserLoginTest(StaticLiveServerTestCase):
         chrome_options = Options()
         # runs headless chrome for wsl environments
         if (
-            "linux" in platform.uname()[0].lower() 
+            "linux" in platform.uname()[0].lower()
             and "microsoft" in platform.uname()[2].lower()
         ):
-            chrome_options.add_argument('--headless')
+            chrome_options.add_argument("--headless")
 
         cls.selenium = WebDriver(chrome_options=chrome_options)
         cls.selenium.implicitly_wait(5)
@@ -55,9 +57,9 @@ class UserLoginTest(StaticLiveServerTestCase):
             username="myuser", password="secret", email="myuser@example.com"
         )
         self.selenium.get("%s%s" % (self.live_server_url, "/login/"))
-        username_input = self.selenium.find_element(By.NAME,"username")
+        username_input = self.selenium.find_element(By.NAME, "username")
         username_input.send_keys("myuser@example.com")
-        password_input = self.selenium.find_element(By.NAME,"password")
+        password_input = self.selenium.find_element(By.NAME, "password")
         password_input.send_keys("secret")
         login_button = self.selenium.find_element(By.XPATH, '//input[@value="login"]')
         login_button.click()
@@ -69,11 +71,11 @@ class UserLoginTest(StaticLiveServerTestCase):
             username="myuser", password="secret", email="myuser@example.com"
         )
         self.selenium.get("%s%s" % (self.live_server_url, "/login/"))
-        username_input = self.selenium.find_element(By.NAME,"username")
+        username_input = self.selenium.find_element(By.NAME, "username")
         username_input.send_keys("myuser@example.com")
-        password_input = self.selenium.find_element(By.NAME,"password")
+        password_input = self.selenium.find_element(By.NAME, "password")
         password_input.send_keys("wrongsecret")
-        login_button = self.selenium.find_element(By.XPATH,'//input[@value="login"]')
+        login_button = self.selenium.find_element(By.XPATH, '//input[@value="login"]')
         login_button.click()
 
         assert "you are logged in" not in self.selenium.page_source
@@ -83,11 +85,11 @@ class UserLoginTest(StaticLiveServerTestCase):
             username="myuser", password="secret", email="myuser@example.com"
         )
         self.selenium.get("%s%s" % (self.live_server_url, "/login/"))
-        username_input = self.selenium.find_element(By.NAME,"username")
+        username_input = self.selenium.find_element(By.NAME, "username")
         username_input.send_keys("myuser@example.com")
-        password_input = self.selenium.find_element(By.NAME,"password")
+        password_input = self.selenium.find_element(By.NAME, "password")
         password_input.send_keys("secret")
-        login_button = self.selenium.find_element(By.XPATH,'//input[@value="login"]')
+        login_button = self.selenium.find_element(By.XPATH, '//input[@value="login"]')
         login_button.click()
 
         self.selenium.get("%s%s" % (self.live_server_url, "/logout/"))
@@ -209,7 +211,6 @@ class RequestListTest(TestCase):
         requests_received = response.context["requests_received"]
         assert len(requests_received) == 1
         assert recd_request_1 in requests_sent
-
 
         # two requests in each category
         sent_request_2 = BuddyRequest.objects.create(

--- a/apps/users/tests.py
+++ b/apps/users/tests.py
@@ -6,7 +6,7 @@ from selenium.webdriver.common.by import By
 from .models import User
 from .views import user_can_access_request
 
-from buddy_mentorship.models import BuddyRequest
+from buddy_mentorship.models import BuddyRequest, Profile
 
 import platform
 
@@ -109,7 +109,9 @@ class UserCanAccessRequestTest(TestCase):
         }
         su = User.objects.create_superuser(**params)
         requestee = User.objects.create_user(email="requestee@user.com")
+        Profile.objects.create(user=requestee)
         requestor = User.objects.create_user(email="requestor@user.com")
+        Profile.objects.create(user=requestor)
         someone = User.objects.create_user(email="someone@user.com")
         buddy_request = BuddyRequest.objects.create(
             requestee=requestee, requestor=requestor, message="test message"

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -2,7 +2,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseForbidden
 from django.shortcuts import render, get_object_or_404
 
-from buddy_mentorship.models import BuddyRequest
+from buddy_mentorship.models import BuddyRequest, Profile
 
 
 @login_required(login_url="login")
@@ -13,6 +13,7 @@ def requests_list(request):
         "requests_sent": requests_sent,
         "requests_received": requests_received,
         "title": "Requests",
+        "active_page": "requests"
     }
     return render(request, "users/requests.html", context)
 
@@ -22,7 +23,12 @@ def request_detail(request, request_id: int):
     buddy_request = get_object_or_404(BuddyRequest, pk=request_id)
     if not user_can_access_request(request.user, buddy_request):
         return HttpResponseForbidden("You do not have access to this request")
-    context = {"buddy_request": buddy_request, "title": "Request Detail"}
+    context = {
+        "buddy_request": buddy_request, 
+        "title": "Request Detail",
+        "requestor_profile": Profile.objects.get(user=buddy_request.requestor).id,
+        "requestee_profile": Profile.objects.get(user=buddy_request.requestee).id
+    }
     return render(request, "users/request.html", context)
 
 

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -13,7 +13,7 @@ def requests_list(request):
         "requests_sent": requests_sent,
         "requests_received": requests_received,
         "title": "Requests",
-        "active_page": "requests"
+        "active_page": "requests",
     }
     return render(request, "users/requests.html", context)
 
@@ -24,10 +24,10 @@ def request_detail(request, request_id: int):
     if not user_can_access_request(request.user, buddy_request):
         return HttpResponseForbidden("You do not have access to this request")
     context = {
-        "buddy_request": buddy_request, 
+        "buddy_request": buddy_request,
         "title": "Request Detail",
         "requestor_profile": Profile.objects.get(user=buddy_request.requestor).id,
-        "requestee_profile": Profile.objects.get(user=buddy_request.requestee).id
+        "requestee_profile": Profile.objects.get(user=buddy_request.requestee).id,
     }
     return render(request, "users/request.html", context)
 

--- a/buddy_mentorship/admin.py
+++ b/buddy_mentorship/admin.py
@@ -4,7 +4,7 @@ from .models import BuddyRequest, Profile
 
 @admin.register(BuddyRequest)
 class BuddyRequestAdmin(admin.ModelAdmin):
-    fields = ['request_sent', 'requestee', 'requestor', 'message']
+    fields = ['request_sent', 'requestee', 'requestor', 'message', 'status']
 
 @admin.register(Profile)
 class ProfileAdmin(admin.ModelAdmin):

--- a/buddy_mentorship/models.py
+++ b/buddy_mentorship/models.py
@@ -68,7 +68,7 @@ class BuddyRequest(models.Model):
             ])
             html_message = "".join([
                 f"<p><a href='{os.getenv('APP_URL')}{profile_url}'>",
-                f"{self.requestee.first_name} {self.requestor.last_name}</a> ",
+                f"{self.requestee.first_name} {self.requestee.last_name}</a> ",
                 f"has accepted your Buddy Request. Contact them at ",
                 f"<a href='mailto:{self.requestee.email}'>",
                 f"{self.requestee.email}</a> to begin your mentorship!</p>"
@@ -82,7 +82,6 @@ class BuddyRequest(models.Model):
                 html_message=html_message
             )
         elif self.status == 2:
-            # rejection email
             pass
 
 

--- a/buddy_mentorship/models.py
+++ b/buddy_mentorship/models.py
@@ -1,6 +1,8 @@
+import os
 from django.conf import settings
 from django.core.mail import send_mail
 from django.db import models
+from django.urls import reverse
 from django.utils import timezone
 from apps.users.models import User
 
@@ -34,21 +36,54 @@ class BuddyRequest(models.Model):
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
         if self.status == 0:
+            profile = Profile.objects.get(user=self.requestor)
+            profile_url = reverse('profile', args=[profile.id])
+            plain_message = "".join([
+                f"{self.requestor.first_name} {self.requestor.last_name} ",
+                "sent you a Buddy Request with the following message: \n",
+                f"{self.message}"
+            ])
+            html_message = "".join([
+                f"<p><a href='{os.getenv('APP_URL')}{profile_url}'>",
+                f"{self.requestor.first_name} {self.requestor.last_name}</a> ",
+                f"sent you a Buddy Request ",
+                "with the following message:</p>",
+                f"{self.message}"
+            ])
             send_mail(
                 f"{self.requestor.first_name} sent you a " 
-                "BuddyRequest",
-                self.message,
+                "Buddy Request",
+                plain_message,
                 settings.EMAIL_ADDRESS,
                 [self.requestee.email],
+                html_message=html_message
             )
         elif self.status == 1:
+            profile = Profile.objects.get(user=self.requestee)
+            profile_url = reverse('profile', args=[profile.id])
+            plain_message = "".join([
+                f"{self.requestee.first_name} {self.requestee.last_name} ",
+                "has accepted your Buddy Request. Contact them at ",
+                f"{self.requestee.email} to begin your mentorship!"
+            ])
+            html_message = "".join([
+                f"<p><a href='{os.getenv('APP_URL')}{profile_url}'>",
+                f"{self.requestee.first_name} {self.requestor.last_name}</a> ",
+                f"has accepted your Buddy Request. Contact them at ",
+                f"<a href='mailto:{self.requestee.email}'>",
+                f"{self.requestee.email}</a> to begin your mentorship!</p>"
+            ])
             send_mail(
                 f"{self.requestee.first_name} accepted your " 
-                "BuddyRequest",
-                self.message,
+                "Buddy Request",
+                plain_message,
                 settings.EMAIL_ADDRESS,
                 [self.requestor.email],
+                html_message=html_message
             )
+        elif self.status == 2:
+            # rejection email
+            pass
 
 
 class Profile(models.Model):
@@ -66,11 +101,11 @@ class Profile(models.Model):
 
     def get_short_bio(self):
         trunc_bio = self.bio[:240]
-        if self.bio == trunc_bio:
-            return trunc_bio
         first_nl = trunc_bio.find("\n")
         if first_nl > -1:
             return trunc_bio[:first_nl]
+        if self.bio == trunc_bio:
+            return trunc_bio
         last_dot = trunc_bio.rfind(".")
         last_bang = trunc_bio.rfind("!")
         last_huh = trunc_bio.rfind("?")

--- a/buddy_mentorship/models.py
+++ b/buddy_mentorship/models.py
@@ -6,17 +6,14 @@ from django.urls import reverse
 from django.utils import timezone
 from apps.users.models import User
 
+
 class BuddyRequest(models.Model):
     class Status(models.IntegerChoices):
         NEW = 0
         ACCEPTED = 1
         REJECTED = 2
 
-    status = models.IntegerField(
-                        choices=Status.choices, 
-                        blank=False, 
-                        default=0
-    )
+    status = models.IntegerField(choices=Status.choices, blank=False, default=0)
     request_sent = models.DateTimeField(default=timezone.now)
     requestee = models.ForeignKey(
         User, on_delete=models.CASCADE, related_name="requestee"
@@ -37,51 +34,57 @@ class BuddyRequest(models.Model):
         super().save(*args, **kwargs)
         if self.status == 0:
             profile = Profile.objects.get(user=self.requestor)
-            profile_url = reverse('profile', args=[profile.id])
-            request_detail_url = reverse('request_detail', args=[self.id])
-            plain_message = "".join([
-                f"{self.requestor.first_name} {self.requestor.last_name} ",
-                "sent you a Buddy Request with the following message: \n",
-                f"{self.message}"
-            ])
-            html_message = "".join([
-                f"<p><a href='{os.getenv('APP_URL')}{profile_url}'>",
-                f"{self.requestor.first_name} {self.requestor.last_name}</a> ",
-                f"sent you a <a href='{os.getenv('APP_URL')}{request_detail_url}''>",
-                f"Buddy Request</a> ",
-                "with the following message:</p>",
-                f"{self.message}"
-            ])
+            profile_url = reverse("profile", args=[profile.id])
+            request_detail_url = reverse("request_detail", args=[self.id])
+            plain_message = "".join(
+                [
+                    f"{self.requestor.first_name} {self.requestor.last_name} ",
+                    "sent you a Buddy Request with the following message: \n",
+                    f"{self.message}",
+                ]
+            )
+            html_message = "".join(
+                [
+                    f"<p><a href='{os.getenv('APP_URL')}{profile_url}'>",
+                    f"{self.requestor.first_name} {self.requestor.last_name}</a> ",
+                    f"sent you a <a href='{os.getenv('APP_URL')}{request_detail_url}''>",
+                    f"Buddy Request</a> ",
+                    "with the following message:</p>",
+                    f"{self.message}",
+                ]
+            )
             send_mail(
-                f"{self.requestor.first_name} sent you a " 
-                "Buddy Request",
+                f"{self.requestor.first_name} sent you a " "Buddy Request",
                 plain_message,
                 settings.EMAIL_ADDRESS,
                 [self.requestee.email],
-                html_message=html_message
+                html_message=html_message,
             )
         elif self.status == 1:
             profile = Profile.objects.get(user=self.requestee)
-            profile_url = reverse('profile', args=[profile.id])
-            plain_message = "".join([
-                f"{self.requestee.first_name} {self.requestee.last_name} ",
-                "has accepted your Buddy Request. Contact them at ",
-                f"{self.requestee.email} to begin your mentorship!"
-            ])
-            html_message = "".join([
-                f"<p><a href='{os.getenv('APP_URL')}{profile_url}'>",
-                f"{self.requestee.first_name} {self.requestee.last_name}</a> ",
-                f"has accepted your Buddy Request. Contact them at ",
-                f"<a href='mailto:{self.requestee.email}'>",
-                f"{self.requestee.email}</a> to begin your mentorship!</p>"
-            ])
+            profile_url = reverse("profile", args=[profile.id])
+            plain_message = "".join(
+                [
+                    f"{self.requestee.first_name} {self.requestee.last_name} ",
+                    "has accepted your Buddy Request. Contact them at ",
+                    f"{self.requestee.email} to begin your mentorship!",
+                ]
+            )
+            html_message = "".join(
+                [
+                    f"<p><a href='{os.getenv('APP_URL')}{profile_url}'>",
+                    f"{self.requestee.first_name} {self.requestee.last_name}</a> ",
+                    f"has accepted your Buddy Request. Contact them at ",
+                    f"<a href='mailto:{self.requestee.email}'>",
+                    f"{self.requestee.email}</a> to begin your mentorship!</p>",
+                ]
+            )
             send_mail(
-                f"{self.requestee.first_name} accepted your " 
-                "Buddy Request",
+                f"{self.requestee.first_name} accepted your " "Buddy Request",
                 plain_message,
                 settings.EMAIL_ADDRESS,
                 [self.requestor.email],
-                html_message=html_message
+                html_message=html_message,
             )
         elif self.status == 2:
             pass
@@ -112,5 +115,6 @@ class Profile(models.Model):
         last_huh = trunc_bio.rfind("?")
         last_sentence = max(last_dot, last_bang, last_huh)
         if last_sentence > -1:
-            return trunc_bio[:last_sentence+1]
-        return trunc_bio[:trunc_bio.rfind(" ")+1]
+            return trunc_bio[: last_sentence + 1]
+        return trunc_bio[: trunc_bio.rfind(" ") + 1]
+

--- a/buddy_mentorship/models.py
+++ b/buddy_mentorship/models.py
@@ -38,6 +38,7 @@ class BuddyRequest(models.Model):
         if self.status == 0:
             profile = Profile.objects.get(user=self.requestor)
             profile_url = reverse('profile', args=[profile.id])
+            request_detail_url = reverse('request_detail', args=[self.id])
             plain_message = "".join([
                 f"{self.requestor.first_name} {self.requestor.last_name} ",
                 "sent you a Buddy Request with the following message: \n",
@@ -46,7 +47,8 @@ class BuddyRequest(models.Model):
             html_message = "".join([
                 f"<p><a href='{os.getenv('APP_URL')}{profile_url}'>",
                 f"{self.requestor.first_name} {self.requestor.last_name}</a> ",
-                f"sent you a Buddy Request ",
+                f"sent you a <a href='{os.getenv('APP_URL')}{request_detail_url}''>",
+                f"Buddy Request</a> ",
                 "with the following message:</p>",
                 f"{self.message}"
             ])

--- a/buddy_mentorship/tests.py
+++ b/buddy_mentorship/tests.py
@@ -6,7 +6,7 @@ from django.test import (
     override_settings,
     TestCase,
     override_settings,
-    TransactionTestCase
+    TransactionTestCase,
 )
 from django.core import mail
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
@@ -173,12 +173,14 @@ class SendBuddyRequestTest(TestCase):
         assert not BuddyRequest.objects.filter(requestor=mentee, requestee=mentor)
 
         c.force_login(mentee)
-        response = c.post(f"/send_request/{mentor.uuid}", {'message': "Please be my mentor."})
+        response = c.post(
+            f"/send_request/{mentor.uuid}", {"message": "Please be my mentor."}
+        )
         assert response.status_code == 302
         assert BuddyRequest.objects.get(requestor=mentee)
 
         assert len(mail.outbox) == 1
-        assert mail.outbox[0].subject == 'Cassie sent you a Buddy Request'
+        assert mail.outbox[0].subject == "Cassie sent you a Buddy Request"
         profile_link = f"<a href='{os.getenv('APP_URL')}{reverse('profile',args=[mentee_profile.id])}'>"
         mentee_name = f"{mentee.first_name} {mentee.last_name}"
         sent_message = mail.outbox[0].alternatives[0][0]
@@ -186,25 +188,25 @@ class SendBuddyRequestTest(TestCase):
         assert mentee_name in sent_message
         assert mentor.email in mail.outbox[0].recipients()
 
-        response = c.post(f"/send_request/{mentor.uuid}", {'message': "Please be my mentor."})
+        response = c.post(
+            f"/send_request/{mentor.uuid}", {"message": "Please be my mentor."}
+        )
         assert response.status_code == 403
         assert len(BuddyRequest.objects.filter(requestor=mentee, requestee=mentor)) == 1
-    
+
     def test_accept_request(self):
         c = Client()
         mentee = User.objects.get(email="mentee@user.com")
         mentor = User.objects.get(email="mentor@user.com")
         mentor_profile = Profile.objects.get(user=mentor)
         buddy_request = BuddyRequest.objects.create(
-            requestor=mentee,
-            requestee=mentor,
-            message="Please be my mentor"
+            requestor=mentee, requestee=mentor, message="Please be my mentor"
         )
         buddy_request.status = 1
         buddy_request.save()
 
         assert len(mail.outbox) == 2
-        assert mail.outbox[1].subject == 'Frank accepted your Buddy Request'
+        assert mail.outbox[1].subject == "Frank accepted your Buddy Request"
         profile_link = f"<a href='{os.getenv('APP_URL')}{reverse('profile',args=[mentor_profile.id])}'>"
         mentor_name = f"{mentor.first_name} {mentor.last_name}"
         sent_message = mail.outbox[1].alternatives[0][0]

--- a/buddy_mentorship/urls.py
+++ b/buddy_mentorship/urls.py
@@ -25,7 +25,11 @@ urlpatterns = [
     path("profile/", views.profile, name="your_profile"),
     path("profile/<int:profile_id>", views.profile, name="profile"),
     path("send_request/<uuid:uuid>", views.send_request, name="send_request"),
-    path("update_request/<int:buddy_request_id>", views.update_request, name="update_request"),
+    path(
+        "update_request/<int:buddy_request_id>",
+        views.update_request,
+        name="update_request",
+    ),
     path("social/", include("social_django.urls", namespace="social")),
-    path("search/", views.Search.as_view(), name="search")
+    path("search/", views.Search.as_view(), name="search"),
 ]

--- a/buddy_mentorship/urls.py
+++ b/buddy_mentorship/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     path("profile/", views.profile, name="your_profile"),
     path("profile/<int:profile_id>", views.profile, name="profile"),
     path("send_request/<uuid:uuid>", views.send_request, name="send_request"),
+    path("update_request/<int:buddy_request_id>", views.update_request, name="update_request"),
     path("social/", include("social_django.urls", namespace="social")),
     path("search/", views.Search.as_view(), name="search")
 ]

--- a/buddy_mentorship/views.py
+++ b/buddy_mentorship/views.py
@@ -73,7 +73,7 @@ def update_request(request, buddy_request_id):
     if request.POST['status'] == "ignore":
         buddy_request.status = 2
     buddy_request.save()
-    return redirect("requests")
+    return redirect("request_detail", request_id=buddy_request_id)
 
 
 class Search(LoginRequiredMixin, ListView):

--- a/buddy_mentorship/views.py
+++ b/buddy_mentorship/views.py
@@ -32,9 +32,9 @@ def profile(request, profile_id=""):
 def send_request(request, uuid):
     user = request.user
     requestee = User.objects.get(uuid=uuid)
-    if request.method != 'POST':
+    if request.method != "POST":
         return HttpResponseForbidden("Error - page accessed incorrectly")
-    message = request.POST['message']
+    message = request.POST["message"]
     if can_request(user, requestee):
         BuddyRequest.objects.create(
             requestor=user, requestee=requestee, message=message
@@ -64,14 +64,14 @@ def can_request(requestor, requestee):
 
 @login_required(login_url="login")
 def update_request(request, buddy_request_id):
-    buddy_request = BuddyRequest.objects.get(id=buddy_request_id)    
+    buddy_request = BuddyRequest.objects.get(id=buddy_request_id)
     if request.user != buddy_request.requestor:
         return HttpResponseForbidden("You cannot accept or reject this request")
-    if request.method != 'POST':
+    if request.method != "POST":
         return HttpResponseForbidden("Error - page accessed incorrectly")
-    if request.POST['status'] == "accept":
+    if request.POST["status"] == "accept":
         buddy_request.status = 1
-    if request.POST['status'] == "ignore":
+    if request.POST["status"] == "ignore":
         buddy_request.status = 2
     buddy_request.save()
     return redirect("request_detail", request_id=buddy_request_id)
@@ -80,9 +80,11 @@ def update_request(request, buddy_request_id):
 class Search(LoginRequiredMixin, ListView):
     login_url = "login"
 
+    template_name = "buddy_mentorship/search.html"
+
     paginate_by = 5
 
-    queryset = Profile.objects.all().order_by('-id')
+    queryset = Profile.objects.all().order_by("-id")
 
     def get_queryset(self):
         all_mentors = self.queryset.filter(can_help=True)
@@ -94,21 +96,17 @@ class Search(LoginRequiredMixin, ListView):
                 search_vector = SearchVector(
                     "user__first_name", "user__last_name", "bio",
                 )
-                search_query = SearchQuery(query_text, search_type='plain')
-                search_results = search_results.annotate(
-                    search=search_vector
-                ).filter(search=search_query)
+                search_query = SearchQuery(query_text, search_type="plain")
+                search_results = search_results.annotate(search=search_vector).filter(
+                    search=search_query
+                )
                 search_results = search_results.annotate(
                     rank=SearchRank(search_vector, search_query)
                 ).order_by("-rank")
         return search_results
-
-    template_name = "buddy_mentorship/search.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["active_page"] = "search"
         context["query_text"] = self.request.GET.get("q", None)
         return context
-
-

--- a/buddy_mentorship/views.py
+++ b/buddy_mentorship/views.py
@@ -53,7 +53,8 @@ def can_request(requestor, requestee):
     )
 
     return (
-        requestor_profile.help_wanted
+        requestor != requestee
+        and requestor_profile.help_wanted
         and requestee_profile.can_help
         and requestor.is_active
         and requestee.is_active

--- a/buddy_mentorship/views.py
+++ b/buddy_mentorship/views.py
@@ -61,6 +61,21 @@ def can_request(requestor, requestee):
     )
 
 
+@login_required(login_url="login")
+def update_request(request, buddy_request_id):
+    buddy_request = BuddyRequest.objects.get(id=buddy_request_id)    
+    if request.user != buddy_request.requestor:
+        return HttpResponseForbidden("You cannot accept or reject this request")
+    if request.method != 'POST':
+        return HttpResponseForbidden("Error - page accessed incorrectly")
+    if request.POST['status'] == "accept":
+        buddy_request.status = 1
+    if request.POST['status'] == "ignore":
+        buddy_request.status = 2
+    buddy_request.save()
+    return redirect("requests")
+
+
 class Search(LoginRequiredMixin, ListView):
     login_url = "login"
 
@@ -94,3 +109,5 @@ class Search(LoginRequiredMixin, ListView):
         context["active_page"] = "search"
         context["query_text"] = self.request.GET.get("q", None)
         return context
+
+


### PR DESCRIPTION
Adds ability to approve/reject requests through UI & adds links to profiles, request for emails sent on request and match. Should close #13, #41, #43 

Not sure "ignored" (rejected) requests are handled correctly. Currently, ignored requests are removed from the requestee's request list, remain on requestor's list as "pending", and do not send notifications on rejection.


