### PR TITLE
remove rejected requests from request list

### DIFF
--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -8,17 +8,21 @@ from buddy_mentorship.models import BuddyRequest, Profile
 @login_required(login_url="login")
 def requests_list(request):
     requests_sent = BuddyRequest.objects.filter(
-        requestor=request.user, request_type=BuddyRequest.RequestType.REQUEST
-    )
+        requestor=request.user, request_type=BuddyRequest.RequestType.REQUEST,
+    ).exclude(status=BuddyRequest.Status.REJECTED)
+
     requests_received = BuddyRequest.objects.filter(
         requestee=request.user, request_type=BuddyRequest.RequestType.REQUEST
-    )
+    ).exclude(status=BuddyRequest.Status.REJECTED)
+
     offers_sent = BuddyRequest.objects.filter(
         requestor=request.user, request_type=BuddyRequest.RequestType.OFFER
-    )
+    ).exclude(status=BuddyRequest.Status.REJECTED)
+
     offers_received = BuddyRequest.objects.filter(
         requestee=request.user, request_type=BuddyRequest.RequestType.OFFER
-    )
+    ).exclude(status=BuddyRequest.Status.REJECTED)
+
     context = {
         "requests_sent": requests_sent,
         "requests_received": requests_received,


### PR DESCRIPTION
Closes #61 
Request list and request detail unit tests were not running; also edits those tests so they run and fixes them so they don't fail.