### PR TITLE
Order skills in search

### DIFF
--- a/buddy_mentorship/models.py
+++ b/buddy_mentorship/models.py
@@ -133,25 +133,26 @@ class Profile(models.Model):
         ).order_by("-level")
         if query:
             vector = SearchVector("skill__skill")
-            results = results.annotate(rank=SearchRank(vector, query))
+            or_query = SearchQuery(query.replace(" ", " | "), search_type="raw")
+            results = results.annotate(rank=SearchRank(vector, or_query))
             results = results.order_by("-rank")
         return results
 
     def get_help_wanted(self, query=""):
         results = Experience.objects.filter(
             profile=self, exp_type=Experience.Type.WANT_HELP
-        ).order_by("-level")
+        ).order_by("level")
         if query:
             vector = SearchVector("skill__skill")
             results = results.annotate(rank=SearchRank(vector, query))
             results = results.order_by("-rank")
         return results
 
-    def get_top_can_help(self):
-        return self.get_can_help()[:3]
+    def get_top_can_help(self, query=""):
+        return self.get_can_help(query)[:3]
 
-    def get_top_help_wanted(self):
-        return self.get_help_wanted()[:3]
+    def get_top_want_help(self, query=""):
+        return self.get_help_wanted(query)[:3]
 
 
 class Skill(models.Model):

--- a/buddy_mentorship/templates/buddy_mentorship/base.html
+++ b/buddy_mentorship/templates/buddy_mentorship/base.html
@@ -74,7 +74,7 @@
           {% if user.is_authenticated %}
           <a class="nav-link" href="{% url 'logout' %}">Logout</a>
           {% else %}
-          <a class="nav-link" href="{% url 'login' %}">Login</a>
+          <a class="nav-link" href="{% url 'social:begin' 'github' %}">Login</a>
           {% endif %}
         </button>
       </div>

--- a/buddy_mentorship/templates/buddy_mentorship/base.html
+++ b/buddy_mentorship/templates/buddy_mentorship/base.html
@@ -74,7 +74,7 @@
           {% if user.is_authenticated %}
           <a class="nav-link" href="{% url 'logout' %}">Logout</a>
           {% else %}
-          <a class="nav-link" href="{% url 'social:begin' 'github' %}">Login</a>
+          <a class="nav-link" href="{% url 'login' %}">Login</a>
           {% endif %}
         </button>
       </div>

--- a/buddy_mentorship/templates/buddy_mentorship/search.html
+++ b/buddy_mentorship/templates/buddy_mentorship/search.html
@@ -187,14 +187,14 @@
                     </tr>
                   </thead>
                   <tbody>
-                    {% for profile in profile_list %}
+                    {% for result in results %}
                       <tr>
-                        <td class="text-nowrap"><a href="{% url 'profile' profile.id %}">{{profile.user.first_name}} {{profile.user.last_name}}</a></td>
-                        <td>{{profile.get_short_bio}}</td>
+                        <td class="text-nowrap"><a href="{% url 'profile' result.profile.id %}">{{result.profile.user.first_name}} {{result.profile.user.last_name}}</a></td>
+                        <td>{{result.profile.get_short_bio}}</td>
                         <td>
                           <ul class="list-group list-group-flush">
                             {% if search_type == 'mentor' %}
-                              {% for experience in profile.get_top_can_help %}
+                              {% for experience in result.can_help %}
                                 <li class="list-group-item d-flex justify-content-between align-items-center">
                                   {{experience.skill.display_name}}
                                   <span class="badge badge-primary badge-pill">{{experience.level}}/5</span>
@@ -202,7 +202,7 @@
                               {% endfor %}
                             {% endif %}
                             {% if search_type == 'mentee' %}
-                              {% for experience in profile.get_top_help_wanted %}
+                              {% for experience in result.want_help %}
                                 <li class="list-group-item d-flex justify-content-between align-items-center">
                                   {{experience.skill.display_name}}
                                   <span class="badge badge-primary badge-pill">{{experience.level}}/5</span>

--- a/buddy_mentorship/tests.py
+++ b/buddy_mentorship/tests.py
@@ -754,6 +754,7 @@ class SearchTest(TestCase):
     def test_mentor_search_skill_order(self):
         user = User.objects.get(email="elizabeth@bennet.org")
         mentor1 = User.objects.get(email="mr@bennet.org")
+        mentor2 = User.objects.get(email="charlotte@lucas.org")
         flask_exp = Experience.objects.get(profile__user=mentor1, skill__skill="Flask")
         pandas_exp = Experience.objects.get(
             profile__user=mentor1, skill__skill="pandas"
@@ -769,10 +770,13 @@ class SearchTest(TestCase):
 
         response = c.get("/search/?type=mentor&q=gentleman+flask")
         search_results = list(response.context_data["results"])
-        assert len(search_results) == 1
-        result = search_results[0]
-        assert result["profile"].user == mentor1
-        assert list(result["can_help"]) == [flask_exp, pandas_exp]
+        assert len(search_results) == 2
+        assert search_results[0]["profile"].user == mentor1
+        assert list(search_results[0]["can_help"]) == [flask_exp, pandas_exp]
+        assert search_results[1]["profile"].user == mentor2
+        assert list(search_results[1]["can_help"]) == [
+            Experience.objects.get(profile__user=mentor2, skill__skill="Flask")
+        ]
 
 
 class SkillTest(TestCase):

--- a/buddy_mentorship/views.py
+++ b/buddy_mentorship/views.py
@@ -266,7 +266,9 @@ class Search(LoginRequiredMixin, ListView):
                 "bio",
                 "experience__skill__skill",
             )
-            search_query = SearchQuery(query_text, search_type="plain")
+            search_query = SearchQuery(
+                query_text.replace(" ", " | "), search_type="raw"
+            )
             search_results = (
                 all_qualified.annotate(
                     search=search_vector, rank=SearchRank(search_vector, search_query),

--- a/buddy_mentorship/views.py
+++ b/buddy_mentorship/views.py
@@ -289,6 +289,15 @@ class Search(LoginRequiredMixin, ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["active_page"] = "search"
-        context["query_text"] = self.request.GET.get("q", "")
         context["search_type"] = self.request.GET.get("type", "mentor")
+        query_text = self.request.GET.get("q", "")
+        context["query_text"] = query_text
+        results = []
+        for profile in context["page_obj"].object_list:
+            result = {}
+            result["profile"] = profile
+            result["can_help"] = profile.get_top_can_help(query_text)
+            result["want_help"] = profile.get_top_want_help(query_text)
+            results.append(result)
+        context["results"] = results
         return context


### PR DESCRIPTION
Closes #82. Also changes search view from requiring all query terms to match to requiring any query term to match. Given that results are already ordered by relevancy, this seemed like a way to decrease frustration (e.g. with having to know the magic combo of words) without losing ease of finding relevant results.

Big assist from @rifferreinert on this one.