### PR TITLE
change server email, don't propagate exceptions

### DIFF
--- a/buddy_mentorship/settings/base.py
+++ b/buddy_mentorship/settings/base.py
@@ -165,6 +165,7 @@ EMAIL_PORT = os.environ["EMAIL_PORT"]
 EMAIL_HOST_USER = os.environ["EMAIL_HOST_USER"]
 EMAIL_HOST_PASSWORD = os.environ["EMAIL_HOST_PASSWORD"]
 EMAIL_USE_SSL = True
+SERVER_EMAIL = EMAIL_ADDRESS
 
 # used for selenium tests
 CHROME_HEADLESS = os.getenv("CHROME_HEADLESS") == "true"

--- a/buddy_mentorship/settings/production.py
+++ b/buddy_mentorship/settings/production.py
@@ -24,6 +24,4 @@ ADMINS = [tuple(os.getenv("ADMINS").split(","))] if os.getenv("ADMINS") else []
 
 django_heroku.settings(locals())
 
-DEBUG_PROPAGATE_EXCEPTIONS = True
-
 SECURE_SSL_REDIRECT = True


### PR DESCRIPTION
The debug_propagate_exceptions setting prevents debug emails from being sent to admins. I also changed the server email in case emails from root@localhost to the chipy web admins email to avoid getting caught in sendgrid/stuck in spam.

Closes #120