### PR TITLE
Open link to source code in a new tab

### DIFF
--- a/buddy_mentorship/templates/buddy_mentorship/base.html
+++ b/buddy_mentorship/templates/buddy_mentorship/base.html
@@ -93,7 +93,7 @@
     <div class="container">
       <span class="text-muted">
         &copy; {% now "Y" %} {% trans "Chicago Python User Group" %}. {% trans "Source code available on " %}<a
-          href="https://github.com/chicagopython/buddy_mentorship">Github</a>.
+          href="https://github.com/chicagopython/buddy_mentorship" target="_blank">Github</a>.
       </span>
     </div>
   </footer>


### PR DESCRIPTION
Hi, I was editing my profile (without saving). I clicked the `Source code available on Github` link to see if the bio section  of my profile supports markdown, then I notice that the link open in the same tab. Which scared me, because it made me think I lost all the information in my profile.