### PR TITLE
Factor out email templates & tweak language to indicate noreply

### DIFF
--- a/buddy_mentorship/templates/buddy_mentorship/email/new_request.html
+++ b/buddy_mentorship/templates/buddy_mentorship/email/new_request.html
@@ -1,0 +1,16 @@
+<p>
+    <a href='{{APP_URL}}{{profile_url}}'>
+        {{requestor.first_name}} {{requestor.last_name}}
+    </a>
+    has sent you a Mentorship
+    <a href='{{APP_URL}}{{request_detail_url}}'>{{request_type_str}}</a>
+    with the following message:
+</p>
+
+<blockquote>
+    {{message}}
+</blockquote>
+
+<p>
+    You can go to the <a href='{{APP_URL}}{{request_detail_url}}'>request detail page</a> to respond to {{requestor.first_name}}'s request.
+</p>

--- a/buddy_mentorship/templates/buddy_mentorship/email/request_accepted.html
+++ b/buddy_mentorship/templates/buddy_mentorship/email/request_accepted.html
@@ -1,0 +1,6 @@
+<p>
+    <a href='{{APP_URL}}{{profile_url}}'>
+    {{requestee.first_name}} {{requestee.last_name}}</a>
+    has accepted your Mentorship {{request_type_str}}. Contact {{requestee.first_name}} at 
+    <a href='mailto:{{requestee.email}}'>{{requestee.email}}</a> to begin your mentorship!
+</p>

--- a/buddy_mentorship/templates/buddy_mentorship/release_notes.html
+++ b/buddy_mentorship/templates/buddy_mentorship/release_notes.html
@@ -13,6 +13,7 @@
     </ul>
     <h4>Changed:</h4>
     <ul>
+        <li>Added language to new request emails to explain how to respond.</li>
     </ul>
     <h4>Fixed:</h4>
     <ul>


### PR DESCRIPTION
Added language to the email sent when a request is accepted to tell them how to respond (and that it's not by replying to that email). Closes #144

In process, factored email content out into separate template files, which will make it easier to tweak & redesign them in the future.