### PR TITLE
End states for mentorship requests

### DIFF
--- a/apps/users/templates/users/request.html
+++ b/apps/users/templates/users/request.html
@@ -109,7 +109,7 @@
                 {{ buddy_request.requestee.email }}</a>.</p>
               {% endif %}
               <p>
-                Has your mentorship run its course?
+                <b>Have you completed your mentorship?</b>
                 <form action="{% url 'complete_mentorship' buddy_request.id %}" method="post" id="complete_mentorship">
                   {% csrf_token %}
                   <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#completeModal">Complete Mentorship</button>

--- a/apps/users/templates/users/request.html
+++ b/apps/users/templates/users/request.html
@@ -108,6 +108,64 @@
               <a href="mailto:{{ buddy_request.requestee.email }}">
                 {{ buddy_request.requestee.email }}</a>.</p>
               {% endif %}
+              <p>
+                Has your mentorship run its course?
+                <form action="{% url 'complete_mentorship' buddy_request.id %}" method="post" id="complete_mentorship">
+                  {% csrf_token %}
+                  <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#completeModal">Complete Mentorship</button>
+              </p>
+
+              <div class="modal fade" id="completeModal" tabindex="-1" role="dialog" aria-labelledby="completeModalLabel"
+                aria-hidden="true">
+                <div class="modal-dialog" role="document">
+                  <div class="modal-content">
+                    <div class="modal-header">
+                      <h5 class="modal-title" id="acceptModalLabel">
+                        Complete Mentorship
+                      </h5>
+                      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                      </button>
+                    </div>
+                    <div class="modal-body">
+                      Please confirm you want to complete this mentorship.
+                    </div>
+                    <div class="modal-footer">
+                      <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                      <button type="submit" class="btn btn-primary" name="status" value="complete">Complete</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </form>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    {% endif %}
+    {% if buddy_request.status == 3 %}
+    <div class="row mb-2">
+      <div class="col">
+        <div class="card">
+          <div class="card-body">
+            <div class="card-title h5">
+              <span class="badge badge-primary">
+                Mentorship Complete
+              </span>
+            </div>
+            <div class="card-text">
+              {% if user == buddy_request.requestee %}
+              Reconnect with {{buddy_request.requestor.first_name}} at
+              <a href="mailto:{{ buddy_request.requestor.email }}">
+                {{ buddy_request.requestor.email }}</a>.</p>
+              {% endif %}
+              {% if user == buddy_request.requestor %}
+              Reconnect with {{buddy_request.requestee.first_name}} at
+              <a href="mailto:{{ buddy_request.requestee.email }}">
+                {{ buddy_request.requestee.email }}</a>.</p>
+              {% endif %}
             </div>
           </div>
         </div>

--- a/apps/users/templates/users/requests.html
+++ b/apps/users/templates/users/requests.html
@@ -25,6 +25,9 @@
         {% if request.status == 1 %}
           <span class="badge badge-success badge-pill">Accepted</span>
         {% endif %}
+        {% if request.status == 3 %}
+          <span class="badge badge-primary badge-pill">Completed</span>
+        {% endif %}
       </li>
     {% endif %}
   {% endfor %}
@@ -39,17 +42,22 @@
     <li> You have not sent any requests </li>
   {% endif %}
   {% for request in requests_sent %}
-    <li class="list-group-item d-flex justify-content-between align-items-center">
-      <a href="/requests/{{ request.id }}">
-        To: {{ request.requestee.first_name }} {{ request.requestee.last_name }}
-      </a>
+    {% if request.status != 2 %}
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <a href="/requests/{{ request.id }}">
+          To: {{ request.requestee.first_name }} {{ request.requestee.last_name }}
+        </a>
       {% if request.status == 0 %}
         <span class="badge badge-secondary badge-pill">Pending</span>
       {% endif %}
       {% if request.status == 1 %}
         <span class="badge badge-success badge-pill">Accepted</span>
       {% endif %}
+      {% if request.status == 3 %}
+        <span class="badge badge-primary badge-pill">Completed</span>
+      {% endif %}
     </li>
+    {% endif %}
   {% endfor %}
 </ul>
 
@@ -65,14 +73,17 @@
     {% if request.status != 2 %}
       <li class="list-group-item d-flex justify-content-between align-items-center">
         <a href="/requests/{{ request.id }}">
-          From: {{ request.requestor.first_name }} {{ request.requestor.last_name }}
+          To: {{ request.requestee.first_name }} {{ request.requestee.last_name }}
         </a>
-        {% if request.status == 0 %}
-          <span class="badge badge-secondary badge-pill">Pending</span>
-        {% endif %}
-        {% if request.status == 1 %}
-          <span class="badge badge-success badge-pill">Accepted</span>
-        {% endif %}
+      {% if request.status == 0 %}
+        <span class="badge badge-secondary badge-pill">Pending</span>
+      {% endif %}
+      {% if request.status == 1 %}
+        <span class="badge badge-success badge-pill">Accepted</span>
+      {% endif %}
+      {% if request.status == 3 %}
+        <span class="badge badge-primary badge-pill">Completed</span>
+      {% endif %}
       </li>
     {% endif %}
   {% endfor %}
@@ -87,17 +98,22 @@
     <li> You have not sent any offers </li>
   {% endif %}
   {% for request in offers_sent %}
-    <li class="list-group-item d-flex justify-content-between align-items-center">
-      <a href="/requests/{{ request.id }}">
-        To: {{ request.requestee.first_name }} {{ request.requestee.last_name }}
-      </a>
+    {% if request.status != 2 %}
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <a href="/requests/{{ request.id }}">
+          To: {{ request.requestee.first_name }} {{ request.requestee.last_name }}
+        </a>
       {% if request.status == 0 %}
         <span class="badge badge-secondary badge-pill">Pending</span>
       {% endif %}
       {% if request.status == 1 %}
         <span class="badge badge-success badge-pill">Accepted</span>
       {% endif %}
-    </li>
+      {% if request.status == 3 %}
+        <span class="badge badge-primary badge-pill">Completed</span>
+      {% endif %}
+      </li>
+    {% endif %}
   {% endfor %}
 </ul>
 

--- a/buddy_mentorship/models.py
+++ b/buddy_mentorship/models.py
@@ -25,6 +25,7 @@ class BuddyRequest(models.Model):
         NEW = 0
         ACCEPTED = 1
         REJECTED = 2
+        COMPLETED = 3
 
     class RequestType(models.IntegerChoices):
         REQUEST = 0

--- a/buddy_mentorship/templates/buddy_mentorship/email/mentorship_completed.html
+++ b/buddy_mentorship/templates/buddy_mentorship/email/mentorship_completed.html
@@ -1,0 +1,6 @@
+<p>
+    Congratulations! You have completed your mentorship with 
+    {% block name_link %} [other person's name & link to profile] {% endblock name_link %}. 
+    We hope you found the experience valuable and that you consider coming back 
+    to ChiPy Mentorship to start more mentorship relationships in the future.
+</p>

--- a/buddy_mentorship/templates/buddy_mentorship/email/new_request.html
+++ b/buddy_mentorship/templates/buddy_mentorship/email/new_request.html
@@ -1,5 +1,5 @@
 <p>
-    <a href='{{APP_URL}}{{profile_url}}'>
+    <a href='{{APP_URL}}{{requestor_profile_url}}'>
         {{requestor.first_name}} {{requestor.last_name}}
     </a>
     has sent you a Mentorship

--- a/buddy_mentorship/templates/buddy_mentorship/email/request_accepted.html
+++ b/buddy_mentorship/templates/buddy_mentorship/email/request_accepted.html
@@ -1,5 +1,5 @@
 <p>
-    <a href='{{APP_URL}}{{profile_url}}'>
+    <a href='{{APP_URL}}{{requestee_profile_url}}'>
     {{requestee.first_name}} {{requestee.last_name}}</a>
     has accepted your Mentorship {{request_type_str}}. Contact {{requestee.first_name}} at 
     <a href='mailto:{{requestee.email}}'>{{requestee.email}}</a> to begin your mentorship!

--- a/buddy_mentorship/templates/buddy_mentorship/email/requestee_mentorship_completed.html
+++ b/buddy_mentorship/templates/buddy_mentorship/email/requestee_mentorship_completed.html
@@ -1,0 +1,6 @@
+{% extends 'buddy_mentorship/email/mentorship_completed.html'%}
+{% block name_link %}
+    <a href='{{APP_URL}}{{requestor_profile_url}}'>
+        {{requestor.first_name}} {{requestor.last_name}}
+    </a>
+{% endblock name_link %}

--- a/buddy_mentorship/templates/buddy_mentorship/email/requestor_mentorship_completed.html
+++ b/buddy_mentorship/templates/buddy_mentorship/email/requestor_mentorship_completed.html
@@ -1,0 +1,6 @@
+{% extends 'buddy_mentorship/email/mentorship_completed.html'%}
+{% block name_link %}
+    <a href='{{APP_URL}}{{requestee_profile_url}}'>
+        {{requestee.first_name}} {{requestee.last_name}}
+    </a>
+{% endblock name_link %}

--- a/buddy_mentorship/tests.py
+++ b/buddy_mentorship/tests.py
@@ -10,6 +10,7 @@ from django.test import (
 )
 from django.core import mail
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.db import IntegrityError
 from django.urls import reverse
 from django.utils import timezone
 
@@ -23,8 +24,6 @@ from .views import (
 )
 
 from apps.users.models import User
-
-from django.db import IntegrityError
 
 
 class CreateBuddyRequestTest(TransactionTestCase):
@@ -591,7 +590,6 @@ class SendBuddyRequestTest(TestCase):
         buddy_request.status = BuddyRequest.Status.REJECTED
         buddy_request.save()
 
-        # right now this doesn't do anything
         assert len(mail.outbox) == 1
 
     def test_complete_request(self):

--- a/buddy_mentorship/tests.py
+++ b/buddy_mentorship/tests.py
@@ -400,56 +400,29 @@ class SendBuddyRequestTest(TestCase):
             Skill.objects.create(skill="Flask"),
         )
 
-        mentor = User.objects.create_user(
-            first_name="Frank", last_name="Mackey", email="mentor@user.com"
-        )
-
-        mentor_profile = Profile.objects.create(
-            user=mentor,
-            bio="Experienced Undercover detective.",
+        create_test_users(
+            1,
+            "mentor",
+            [{"skill": skill1, "level": 2, "exp_type": Experience.Type.CAN_HELP}],
             looking_for_mentees=True,
             looking_for_mentors=False,
         )
 
-        Experience.objects.create(
-            profile=mentor_profile,
-            skill=skill1,
-            level=2,
-            exp_type=Experience.Type.CAN_HELP,
-        )
-
-        mentee = User.objects.create_user(
-            first_name="Cassie", last_name="Maddox", email="mentee@user.com"
-        )
-
-        mentee_profile = Profile.objects.create(
-            user=mentee,
-            bio="Aspiring Undercover detective with background in Murder.",
+        create_test_users(
+            1,
+            "mentee",
+            [{"skill": skill1, "level": 3, "exp_type": Experience.Type.WANT_HELP}],
             looking_for_mentors=True,
             looking_for_mentees=False,
         )
 
-        Experience.objects.create(
-            profile=mentee_profile,
-            skill=skill1,
-            level=3,
-            exp_type=Experience.Type.WANT_HELP,
-        )
-
-        someone = User.objects.create_user(
-            first_name="Rob", last_name="Ryan", email="someone@user.com"
-        )
-
-        someone_profile = Profile.objects.create(
-            user=someone,
-            bio="You ever see somebody ruin their own life?",
-            looking_for_mentors=False,
-            looking_for_mentees=False,
+        create_test_users(
+            1, "someone", [], looking_for_mentors=False, looking_for_mentees=False,
         )
 
     def test_existing_requests(self):
-        mentee = User.objects.get(email="mentee@user.com")
-        mentor = User.objects.get(email="mentor@user.com")
+        mentee = User.objects.get(email="mentee0@buddy.com")
+        mentor = User.objects.get(email="mentor0@buddy.com")
 
         assert not existing_requests(mentee, mentor)
 
@@ -474,9 +447,9 @@ class SendBuddyRequestTest(TestCase):
         assert existing_requests(mentee, mentor)
 
     def test_required_experiences(self):
-        mentee = User.objects.get(email="mentee@user.com")
-        mentor = User.objects.get(email="mentor@user.com")
-        someone = User.objects.get(email="someone@user.com")
+        mentee = User.objects.get(email="mentee0@buddy.com")
+        mentor = User.objects.get(email="mentor0@buddy.com")
+        someone = User.objects.get(email="someone0@buddy.com")
         assert required_experiences(mentee, mentor)
         assert not required_experiences(mentor, mentee)
         assert not required_experiences(mentee, someone)
@@ -485,11 +458,11 @@ class SendBuddyRequestTest(TestCase):
         assert not required_experiences(mentor, someone)
 
     def test_can_request_as_mentor(self):
-        mentee = User.objects.get(email="mentee@user.com")
+        mentee = User.objects.get(email="mentee0@buddy.com")
         mentee_profile = Profile.objects.get(user=mentee)
-        mentor = User.objects.get(email="mentor@user.com")
+        mentor = User.objects.get(email="mentor0@buddy.com")
         mentor_profile = Profile.objects.get(user=mentor)
-        someone = User.objects.get(email="someone@user.com")
+        someone = User.objects.get(email="someone0@buddy.com")
         assert can_request_as_mentor(mentee, mentor)
 
         mentor.is_active = False
@@ -514,11 +487,11 @@ class SendBuddyRequestTest(TestCase):
         buddy_request.delete()
 
     def test_can_offer_to_mentor(self):
-        mentee = User.objects.get(email="mentee@user.com")
+        mentee = User.objects.get(email="mentee0@buddy.com")
         mentee_profile = Profile.objects.get(user=mentee)
-        mentor = User.objects.get(email="mentor@user.com")
+        mentor = User.objects.get(email="mentor0@buddy.com")
         mentor_profile = Profile.objects.get(user=mentor)
-        someone = User.objects.get(email="someone@user.com")
+        someone = User.objects.get(email="someone0@buddy.com")
         assert can_offer_to_mentor(mentor, mentee)
 
         mentee.is_active = False
@@ -544,8 +517,8 @@ class SendBuddyRequestTest(TestCase):
 
     def test_send_request(self):
         c = Client()
-        mentee = User.objects.get(email="mentee@user.com")
-        mentor = User.objects.get(email="mentor@user.com")
+        mentee = User.objects.get(email="mentee0@buddy.com")
+        mentor = User.objects.get(email="mentor0@buddy.com")
         mentee_profile = Profile.objects.get(user=mentee)
         assert not BuddyRequest.objects.filter(
             requestor=mentee,
@@ -585,8 +558,8 @@ class SendBuddyRequestTest(TestCase):
 
     def test_accept_request(self):
         c = Client()
-        mentee = User.objects.get(email="mentee@user.com")
-        mentor = User.objects.get(email="mentor@user.com")
+        mentee = User.objects.get(email="mentee0@buddy.com")
+        mentor = User.objects.get(email="mentor0@buddy.com")
         mentor_profile = Profile.objects.get(user=mentor)
         buddy_request = BuddyRequest.objects.create(
             requestor=mentee,
@@ -608,19 +581,32 @@ class SendBuddyRequestTest(TestCase):
 
     def test_reject_request(self):
         c = Client()
-        mentee = User.objects.get(email="mentee@user.com")
-        mentor = User.objects.get(email="mentor@user.com")
-        mentor_profile = Profile.objects.get(user=mentor)
+        mentee = User.objects.get(email="mentee0@buddy.com")
+        mentor = User.objects.get(email="mentor0@buddy.com")
         buddy_request = BuddyRequest.objects.create(
             requestor=mentee,
             requestee=mentor,
             request_type=BuddyRequest.RequestType.REQUEST,
         )
-        buddy_request.status = 2
+        buddy_request.status = BuddyRequest.Status.REJECTED
         buddy_request.save()
 
         # right now this doesn't do anything
         assert len(mail.outbox) == 1
+
+    def test_complete_request(self):
+        c = Client()
+        mentee = User.objects.get(email="mentee0@buddy.com")
+        mentor = User.objects.get(email="mentor0@buddy.com")
+        buddy_request = BuddyRequest.objects.create(
+            requestor=mentee,
+            requestee=mentor,
+            request_type=BuddyRequest.RequestType.REQUEST,
+        )
+        buddy_request.status = BuddyRequest.Status.COMPLETED
+        buddy_request.save()
+
+        assert len
 
 
 class SendBuddyOfferTest(TestCase):

--- a/buddy_mentorship/urls.py
+++ b/buddy_mentorship/urls.py
@@ -38,6 +38,11 @@ urlpatterns = [
         views.update_request,
         name="update_request",
     ),
+    path(
+        "complete/<int:buddy_request_id>",
+        views.complete_mentorship,
+        name="complete_mentorship",
+    ),
     path("social/", include("social_django.urls", namespace="social")),
     path("search/", views.Search.as_view(), name="search"),
     path(

--- a/buddy_mentorship/views.py
+++ b/buddy_mentorship/views.py
@@ -334,6 +334,22 @@ def update_request(request, buddy_request_id):
     return redirect("request_detail", request_id=buddy_request_id)
 
 
+@login_required(login_url="login")
+def complete_mentorship(request, buddy_request_id):
+    buddy_request = BuddyRequest.objects.get(id=buddy_request_id)
+    if (
+        request.user != buddy_request.requestee
+        and request.user != buddy_request.requestor
+    ):
+        return HttpResponseForbidden("You cannot mark this mentorship complete.")
+    if request.method != "POST":
+        return HttpResponseForbidden("Error - page accessed incorrectly")
+    if request.POST["status"] == "complete":
+        buddy_request.status = 3
+    buddy_request.save()
+    return redirect("request_detail", request_id=buddy_request_id)
+
+
 class Search(LoginRequiredMixin, ListView):
     login_url = "login"
 


### PR DESCRIPTION
Closes #124. Sorry this one is a bit bulky - some of the cleanup stuff should have been added to a different pull request.

Request detail template:
- Updates to include ability to complete requests. Either party to an accepted request can unilaterally do this.
- Also creates portion of template shown for completed request

Request list template:
- Updates request list to show badges for completed requests.
- Also cleans up request lists so all have uniform behavior (not showing ignored requests)

Models:
- Adds COMPLETED to list of possible statuses
- In save method, reshuffles local variables & context sent to email so can send two emails (one to requestor, one to requestee) in a single call
- Updates save method so that when request status is set to COMPLETED, sends emails notifying both requestor and requestee.

Email templates:
- Creates base "mentorship completed" email template and extends for requestor and requestee

Tests
- Slimmed down setup a bit by using create_test_users function instead of creating all objects associated with a user separately.
- Created unit test for request completion behavior (request & offer versions)
- Created unit tests for complete request view

views, URLs
- added "complete request" view